### PR TITLE
Add support for axes/size(zip(...)) with OneToInf and finite iterators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.10.3"
+version = "0.10.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -151,11 +151,17 @@ done(r::InfStepRange{T}, i) where {T} = false
 
 ## iteration with zip + finite iterator
 #  allows axes(zip(...)) and size(zip(...))
-
-Base.Iterators._zip_promote_shape((a,)::Tuple{OneToInf}, (b,)::Tuple{OneTo}) =
-    (intersect(a, b),)
-Base.Iterators._zip_promote_shape((a,)::Tuple{OneTo}, (b,)::Tuple{OneToInf}) =
-    (intersect(a, b),)
+if VERSION < v"1.6-" 
+    Base.Iterators._zip_promote_shape((a,)::Tuple{OneToInf}, (b,)::Tuple{OneTo}) =
+        (intersect(a, b),)
+    Base.Iterators._zip_promote_shape((a,)::Tuple{OneTo}, (b,)::Tuple{OneToInf}) =
+        (intersect(a, b),)
+else
+    Base.Iterators._promote_tuple_shape((a,)::Tuple{OneToInf}, (b,)::Tuple{OneTo}) =
+        (intersect(a, b),)
+    Base.Iterators._promote_tuple_shape((a,)::Tuple{OneTo}, (b,)::Tuple{OneToInf}) =
+        (intersect(a, b),)
+end
 
 ## indexing
 

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -149,6 +149,14 @@ start(r::OneToInf{T}) where {T} = oneunit(T)
 
 done(r::InfStepRange{T}, i) where {T} = false
 
+## iteration with zip + finite iterator
+#  allows axes(zip(...)) and size(zip(...))
+
+Base.Iterators._zip_promote_shape((a,)::Tuple{OneToInf}, (b,)::Tuple{OneTo}) =
+    (intersect(a, b),)
+Base.Iterators._zip_promote_shape((a,)::Tuple{OneTo}, (b,)::Tuple{OneToInf}) =
+    (intersect(a, b),)
+
 ## indexing
 
 unsafe_indices(S::Slice{<:OneToInf}) = (S.indices,)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -367,6 +367,12 @@ end
         @test intersect(r, 2) === intersect(2, r) === 2:2
 
         @test Base.unsafe_indices(Base.Slice(r)) == (r,)
+
+        @testset "iteration with zip + finite iterator" begin
+            z = zip(OneToInf(), 1:100)
+            @test axes(z) == (Base.OneTo(100),)
+            @test size(z) == (100,)
+        end
     end
 
     @testset "show" begin


### PR DESCRIPTION
This allows for `axes(zip(...))` and `size(zip(...))` to work when `OneToInf` is zipped up with finite iterators. One concern is that the internal function `_zip_promote_shape` changes to `_promote_tuple_shape` in 1.6. Not sure how we want to handle that change. Right now this PR is designed for < 1.6.

fixes #67 