### PR TITLE
Fix indexing for `InfStepRange`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.12.7"
+version = "0.12.8"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -198,6 +198,7 @@ function getindex(v::OneToInf{T}, i::Integer) where T
 end
 function getindex(v::InfStepRange{T}, i::Integer) where T
     @boundscheck i > 0 || Base.throw_boundserror(v, i)
+    i == 1 && return convert(T, first(v))
     convert(T, first(v) + (i - 1)*step(v))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,9 @@ end
 
         @test (1:∞)[Base.Slice(1:∞)] ≡ 1:∞
         @test Base.Slice(1:∞)[2:∞] ≡ 2:∞
+
+        v = InfiniteArrays.InfStepRange(InfiniteCardinal{0}(), InfiniteCardinal{0}())
+        @test v[1] == v[2] == InfiniteCardinal{0}()
     end
     @testset "length" begin
         @test length(.1:.1:∞) == ℵ₀


### PR DESCRIPTION
This works around a `0 * Inf` multiplication while indexing an `InfStepRange`.
Currently, on master,
```julia
julia> v = InfiniteArrays.InfStepRange(InfiniteCardinal{0}(), InfiniteCardinal{0}())
ℵ₀:ℵ₀:+∞

julia> v[1]
ERROR: ArgumentError: 0 is non-positive
Stacktrace:
 [1] *
   @ ~/.julia/packages/Infinities/Y1fpA/src/cardinality.jl:121 [inlined]
 [2] getindex(v::InfiniteArrays.InfStepRange{InfiniteCardinal{0}, InfiniteCardinal{0}}, i::Int64)
   @ InfiniteArrays ~/Dropbox/JuliaPackages/InfiniteArrays.jl/src/infrange.jl:202
 [3] top-level scope
   @ REPL[33]:1
```
After this PR
```julia
julia> v[1]
ℵ₀
```