### PR TITLE
IteratorSize for infinite ranges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.12.8"
+version = "0.12.9"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -75,6 +75,7 @@ struct InfUnitRange{T<:Real} <: AbstractInfUnitRange{T}
     start::T
 end
 
+
 InfUnitRange(a::InfUnitRange) = a
 InfUnitRange{T}(a::AbstractInfUnitRange) where T<:Real = InfUnitRange{T}(first(a))
 InfUnitRange(a::AbstractInfUnitRange{T}) where T<:Real = InfUnitRange{T}(first(a))

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -89,7 +89,7 @@ AbstractVector{T}(a::InfStepRange) where T<:Real = InfStepRange(convert(T,a.star
 const InfRanges{T} = Union{InfStepRange{T},AbstractInfUnitRange{T}}
 const InfAxes = Union{InfRanges{<:Integer},Slice{<:AbstractInfUnitRange{<:Integer}},IdentityUnitRange{<:AbstractInfUnitRange{<:Integer}}}
 
-Base.IteratorSize(::Type{<:InfAxes}) = Base.IsInfinite()
+Base.IteratorSize(::Type{<:InfRanges}) = Base.IsInfinite()
 
 AbstractArray{T}(ac::Adjoint{<:Any,<:InfRanges}) where T<:Real = AbstractArray{T}(parent(ac))'
 AbstractMatrix{T}(ac::Adjoint{<:Any,<:InfRanges}) where T<:Real = AbstractVector{T}(parent(ac))'

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -66,11 +66,7 @@ end
 InfStepRange(start::T, step::S) where {T,S} = InfStepRange{T,S}(start,step)
 InfStepRange{T,S}(start, step) where {T,S} = InfStepRange{T,S}(convert(T,start),convert(S,step))
 
-Base.IteratorSize(::Type{<:InfStepRange}) = Base.IsInfinite()
-
 abstract type AbstractInfUnitRange{T<:Real} <: AbstractUnitRange{T} end
-
-Base.IteratorSize(::Type{<:AbstractInfUnitRange}) = Base.IsInfinite()
 
 done(r::AbstractInfUnitRange{T}, i) where {T} = false
 unitrange_last(start, stop::PosInfinity) = ∞
@@ -78,7 +74,6 @@ unitrange_last(start, stop::PosInfinity) = ∞
 struct InfUnitRange{T<:Real} <: AbstractInfUnitRange{T}
     start::T
 end
-
 
 InfUnitRange(a::InfUnitRange) = a
 InfUnitRange{T}(a::AbstractInfUnitRange) where T<:Real = InfUnitRange{T}(first(a))
@@ -92,6 +87,8 @@ AbstractVector{T}(a::InfStepRange) where T<:Real = InfStepRange(convert(T,a.star
 
 const InfRanges{T} = Union{InfStepRange{T},AbstractInfUnitRange{T}}
 const InfAxes = Union{InfRanges{<:Integer},Slice{<:AbstractInfUnitRange{<:Integer}},IdentityUnitRange{<:AbstractInfUnitRange{<:Integer}}}
+
+Base.IteratorSize(::Type{<:InfAxes}) = Base.IsInfinite()
 
 AbstractArray{T}(ac::Adjoint{<:Any,<:InfRanges}) where T<:Real = AbstractArray{T}(parent(ac))'
 AbstractMatrix{T}(ac::Adjoint{<:Any,<:InfRanges}) where T<:Real = AbstractVector{T}(parent(ac))'

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -66,7 +66,11 @@ end
 InfStepRange(start::T, step::S) where {T,S} = InfStepRange{T,S}(start,step)
 InfStepRange{T,S}(start, step) where {T,S} = InfStepRange{T,S}(convert(T,start),convert(S,step))
 
+Base.IteratorSize(::Type{<:InfStepRange}) = Base.IsInfinite()
+
 abstract type AbstractInfUnitRange{T<:Real} <: AbstractUnitRange{T} end
+
+Base.IteratorSize(::Type{<:AbstractInfUnitRange}) = Base.IsInfinite()
 
 done(r::AbstractInfUnitRange{T}, i) where {T} = false
 unitrange_last(start, stop::PosInfinity) = ∞

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,6 +160,14 @@ end
         @test length(1.:.2:∞) == ℵ₀
         @test length(2:-.2:-∞) == ℵ₀
         @test length(2.:-.2:-∞) == ℵ₀
+
+        @testset "IteratorSize" begin
+            @test Base.IteratorSize(1:2:∞) == Base.IsInfinite()
+            @test Base.IteratorSize(1:∞) == Base.IsInfinite()
+            s = Iterators.Stateful(2:∞)
+            @test first(s) == 2
+            @test first(s) == 3
+        end
     end
 
     @testset "intersect" begin


### PR DESCRIPTION
This lets one use the ranges as iterators, and the following works after this:
```julia
julia> s = Iterators.Stateful(2:∞)
Base.Iterators.Stateful{InfiniteArrays.InfUnitRange{Int64}, Tuple{Int64, Int64}, Int64}(2:∞, (2, 2), -1)

julia> first(s)
2

julia> first(s)
3
```