### PR TITLE
Test for print_matrix_row

### DIFF
--- a/src/InfiniteArrays.jl
+++ b/src/InfiniteArrays.jl
@@ -65,7 +65,14 @@ import Infinities: ∞, Infinity, InfiniteCardinal
 export ∞, ℵ₀, Hcat, Vcat, Zeros, Ones, Fill, Eye, BroadcastArray, cache
 import Base: unitrange, oneto
 
-
+if VERSION ≥ v"1.11.0-DEV.21"
+    using LinearAlgebra: UpperOrLowerTriangular
+else
+    const UpperOrLowerTriangular{T,S} = Union{LinearAlgebra.UpperTriangular{T,S},
+                                              LinearAlgebra.UnitUpperTriangular{T,S},
+                                              LinearAlgebra.LowerTriangular{T,S},
+                                              LinearAlgebra.UnitLowerTriangular{T,S}}
+end
 
 include("infrange.jl")
 include("infarrays.jl")

--- a/src/InfiniteArrays.jl
+++ b/src/InfiniteArrays.jl
@@ -65,14 +65,7 @@ import Infinities: ∞, Infinity, InfiniteCardinal
 export ∞, ℵ₀, Hcat, Vcat, Zeros, Ones, Fill, Eye, BroadcastArray, cache
 import Base: unitrange, oneto
 
-if VERSION ≥ v"1.11.0-DEV.21"
-    using LinearAlgebra: UpperOrLowerTriangular
-else
-    const UpperOrLowerTriangular{T,S} = Union{LinearAlgebra.UpperTriangular{T,S},
-                                              LinearAlgebra.UnitUpperTriangular{T,S},
-                                              LinearAlgebra.LowerTriangular{T,S},
-                                              LinearAlgebra.UnitLowerTriangular{T,S}}
-end
+
 
 include("infrange.jl")
 include("infarrays.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1171,3 +1171,8 @@ end
     @test c[1,2,1] == 2
     @test_broken c[6] == 2
 end
+
+@testset "print_matrix_row" begin
+    # check that show works
+    Base.sprint(show, I(ℵ₀), context=:limit=>true)
+end


### PR DESCRIPTION
This is future-proof, and works around the breakage due to `ArrayLayouts` v1.0.11

After this, `print_matrix_row` works again:
```julia
julia> I(ℵ₀)
ℵ₀×ℵ₀ Diagonal{Bool, LazyArrays.CachedArray{Bool, 1, Vector{Bool}, Fill{Bool, 1, Tuple{InfiniteArrays.OneToInf{Int64}}}}} with indices OneToInf()×OneToInf():
 1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  …  
 ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅     
 ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅     
 ⋅  ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅     
 ⋅  ⋅  ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅     
 ⋅  ⋅  ⋅  ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  …  
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅     
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅  ⋅     
 ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  ⋅  1  ⋅  ⋅  ⋅  ⋅     
 ⋮              ⋮              ⋮        ⋱  
```