### PR TITLE
Remove infinite index indexing test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1105,8 +1105,6 @@ end
 
 @testset "cached indexing" begin
     @test cache(1:∞)[Fill(2,∞)][1:10] == fill(2,10)
-    @test isassigned(cache(1:∞),RealInfinity())
-    @test cache(1:∞)[RealInfinity()] == ∞
     C = cache(Fill(2.0,∞,∞))
     C[1:5,1:5] .= randn.()
     @test C[1:∞,2:∞][1:10,1:10] == C[1:10,2:11]


### PR DESCRIPTION
Since `ℵ₀` isn't a well-defined index for a vector, perhaps indexing using this shouldn't be defined? Currently, this is treated as a key instead of an index, with the array being treated as a map from `i=>vi` that is augmented by the `ℵ₀ => infval` pair.

This PR removes the tests for indexing using `ℵ₀` (although not the `getindex` method, which might be breaking). These are currently failing on v1.10, and I'm unsure if these may be defined consistently. The `isassigned` method is a bit odd in any case, since similar methods are not defined for other arrays (although perhaps that is simply a case of missing methods).