### PR TITLE
Ensure that imports correspond to the parent module

### DIFF
--- a/src/InfiniteArrays.jl
+++ b/src/InfiniteArrays.jl
@@ -1,6 +1,6 @@
 module InfiniteArrays
-using ArrayLayouts: LayoutVecOrMat
-using Base, Statistics, LinearAlgebra, FillArrays, Infinities, LazyArrays, ArrayLayouts
+
+using LinearAlgebra, FillArrays, Infinities, LazyArrays, ArrayLayouts
 
 import Base: *, +, -, /, \, ==, isinf, isfinite, sign, signbit, angle, show, isless,
             fld, cld, div, min, max, minimum, maximum, mod,
@@ -54,12 +54,16 @@ import LinearAlgebra: BlasInt, BlasFloat, norm, diag, diagm, ishermitian, issymm
 import Statistics: mean, median
 
 import FillArrays: AbstractFill, getindex_value, fill_reshape, RectDiagonal, Fill, Ones, Zeros, Eye
-import LazyArrays: LazyArrayStyle, AbstractBandedLayout, MemoryLayout, LazyLayout, UnknownLayout,
-                    ZerosLayout, AbstractCachedVector, CachedArray, CachedVector, ApplyLayout, LazyMatrix,
-                    reshapedlayout, sub_materialize, sublayout, LayoutMatrix, LayoutVector, _padded_sub_materialize, PaddedLayout,
+
+import LazyArrays: LazyArrayStyle, LazyLayout,
+                    AbstractCachedVector, CachedArray, CachedVector, ApplyLayout, LazyMatrix,
+                    _padded_sub_materialize, PaddedLayout,
                     AbstractCachedMatrix, sub_paddeddata, InvColumnLayout
 
-import ArrayLayouts: RangeCumsum, LayoutVecOrMat, LayoutVecOrMats
+import ArrayLayouts: RangeCumsum, LayoutVecOrMat, LayoutVecOrMats, LayoutMatrix, LayoutVector,
+                     AbstractBandedLayout, MemoryLayout, UnknownLayout, reshapedlayout,
+                     sub_materialize, sublayout, ZerosLayout
+
 import Infinities: ∞, Infinity, InfiniteCardinal
 
 export ∞, ℵ₀, Hcat, Vcat, Zeros, Ones, Fill, Eye, BroadcastArray, cache


### PR DESCRIPTION
Some of the `ArrayLayouts` symbols were being imported from `LazyArrays`, and this PR ensures that they are correctly mapped.