### PR TITLE
Move `Statistics` to an extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.12.14"
+version = "0.12.15"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -9,6 +9,12 @@ Infinities = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[weakdeps]
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[extensions]
+InfiniteArraysStatisticsExt = "Statistics"
 
 [compat]
 Aqua = "0.6"
@@ -26,7 +32,8 @@ BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 LazyBandedMatrices = "d7e5e226-e90b-4449-9968-0f923699bf6f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "BandedMatrices", "LazyBandedMatrices", "SparseArrays", "Base64"]
+test = ["Aqua", "Test", "BandedMatrices", "LazyBandedMatrices", "Statistics", "SparseArrays", "Base64"]

--- a/ext/InfiniteArraysStatisticsExt.jl
+++ b/ext/InfiniteArraysStatisticsExt.jl
@@ -1,0 +1,10 @@
+module InfiniteArraysStatisticsExt
+
+using InfiniteArrays
+using InfiniteArrays: InfRanges
+using Statistics
+
+Statistics.mean(r::InfRanges{<:Real}) = last(r)
+Statistics.median(r::InfRanges{<:Real}) = last(r)
+
+end

--- a/src/InfiniteArrays.jl
+++ b/src/InfiniteArrays.jl
@@ -1,6 +1,6 @@
 module InfiniteArrays
 using ArrayLayouts: LayoutVecOrMat
-using Base, Statistics, LinearAlgebra, FillArrays, Infinities, LazyArrays, ArrayLayouts
+using LinearAlgebra, FillArrays, Infinities, LazyArrays, ArrayLayouts
 
 import Base: *, +, -, /, \, ==, isinf, isfinite, sign, signbit, angle, show, isless,
             fld, cld, div, min, max, minimum, maximum, mod,
@@ -50,8 +50,6 @@ import Base.Broadcast: BroadcastStyle, AbstractArrayStyle, Broadcasted, broadcas
 import LinearAlgebra: BlasInt, BlasFloat, norm, diag, diagm, ishermitian, issymmetric,
                              det, logdet, istriu, istril, adjoint, tr, AbstractTriangular,
                              norm2, norm1, normp, AdjOrTrans, HermOrSym
-
-import Statistics: mean, median
 
 import FillArrays: AbstractFill, getindex_value, fill_reshape, RectDiagonal, Fill, Ones, Zeros, Eye
 import LazyArrays: LazyArrayStyle, AbstractBandedLayout, MemoryLayout, LazyLayout, UnknownLayout,
@@ -221,7 +219,9 @@ end
     return LazyArrays.searchsortedlast_recursive(n, x, args...)
 end
 
-
+if !isdefined(Base, :get_extension)
+    include("../ext/InfiniteArraysStatisticsExt.jl")
+end
 
 
 end # module

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -437,8 +437,6 @@ InfStepRange(r::InfUnitRange{T}) where {T} =
 ## sorting ##
 
 sum(r::InfRanges{<:Real}) = last(r)
-mean(r::InfRanges{<:Real}) = last(r)
-median(r::InfRanges{<:Real}) = last(r)
 
 in(x::Union{Infinity,RealInfinity}, r::InfRanges) = false # never reach it...
 in(x::Infinity, r::InfRanges{<:Integer}) = false # never reach it...

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,10 @@ import Base.Broadcast: broadcasted, Broadcasted, instantiate
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(InfiniteArrays, ambiguities=false, piracy=false)
+    Aqua.test_all(InfiniteArrays, ambiguities=false, piracy=false,
+        # only test formatting on VERSION >= v1.7
+        # https://github.com/JuliaTesting/Aqua.jl/issues/105#issuecomment-1551405866
+        project_toml_formatting = VERSION >= v"1.7")
 end
 
 @testset "construction" begin


### PR DESCRIPTION
This doesn't have an immediate impact at present, as `LazyArrays` loads `SparseArrays` at present, but this is preparing for the future. In any case, this removes the explicit dependency on `Statistics`