### PR TITLE
Move infinite conv from InfiniteLinearAlgebra to DSP extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.12.16"
+version = "0.13.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.12.15"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 Infinities = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
@@ -11,15 +12,18 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [extensions]
+InfiniteArraysDSPExt = "DSP"
 InfiniteArraysStatisticsExt = "Statistics"
 
 [compat]
 Aqua = "0.6"
 ArrayLayouts = "1.0"
 BandedMatrices = "0.17.18"
+DSP = "0.7"
 FillArrays = "1.0"
 Infinities = "0.1.1"
 LazyArrays = "1.0"
@@ -30,10 +34,11 @@ julia = "1.6"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 LazyBandedMatrices = "d7e5e226-e90b-4449-9968-0f923699bf6f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "BandedMatrices", "LazyBandedMatrices", "Statistics", "SparseArrays", "Base64"]
+test = ["Aqua", "Test", "BandedMatrices", "LazyBandedMatrices", "Statistics", "SparseArrays", "Base64", "DSP"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.12.15"
+version = "0.12.16"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/ext/InfiniteArraysDSPExt.jl
+++ b/ext/InfiniteArraysDSPExt.jl
@@ -1,0 +1,77 @@
+module InfiniteArraysDSPExt
+
+using InfiniteArrays
+using InfiniteArrays: InfRanges, OneToInf
+using FillArrays
+using FillArrays: AbstractFill, getindex_value
+using LazyArrays
+import DSP: conv
+
+
+##
+# conv
+# This is useful for determining polynomial dimensions
+##
+
+conv(::Ones{T,1,<:Tuple{<:OneToInf}}, ::Ones{V,1,<:Tuple{<:OneToInf}}) where {T<:Integer,V<:Integer} =
+    OneToInf{promote_type(T,V)}()
+conv(::Ones{Bool,1,<:Tuple{<:OneToInf}}, ::Ones{Bool,1,<:Tuple{<:OneToInf}}) =
+    OneToInf()
+conv(::Ones{T,1,<:Tuple{<:OneToInf}}, ::Ones{V,1,<:Tuple{<:OneToInf}}) where {T,V} =
+    one(promote_type(T,V)):∞
+
+function conv(::Ones{T,1,<:Tuple{<:OneToInf}}, a::AbstractVector{V}) where {T,V}
+    cs = cumsum(convert(AbstractVector{promote_type(T,V)}, a))
+    Vcat(cs, Fill(last(cs), ∞))
+end
+
+function conv(::Ones{T,1,<:Tuple{<:OneToInf}}, a::Vector{V}) where {T,V}
+    cs = cumsum(convert(AbstractVector{promote_type(T,V)}, a))
+    Vcat(cs, Fill(last(cs), ∞))
+end
+
+function conv(a::AbstractVector{V}, ::Ones{T,1,<:Tuple{<:OneToInf}}) where {T,V}
+    cs = cumsum(convert(AbstractVector{promote_type(T,V)}, a))
+    Vcat(cs, Fill(last(cs), ∞))
+end
+
+function conv(a::Vector{V}, ::Ones{T,1,<:Tuple{<:OneToInf}}) where {T,V}
+    cs = cumsum(convert(AbstractVector{promote_type(T,V)}, a))
+    Vcat(cs, Fill(last(cs), ∞))
+end
+
+
+function conv(r::InfRanges, x::AbstractVector)
+    length(x) ≠ 1 && throw(ArgumentError("conv(::$(typeof(r)), ::$(typeof(x))) not implemented"))
+    first(x)*r
+end
+function conv(x::AbstractVector, r::InfRanges)
+    length(x) ≠ 1 && throw(ArgumentError("conv(::$(typeof(r)), ::$(typeof(x))) not implemented"))
+    first(x)*r
+end
+
+conv(r1::InfRanges, r2::AbstractFill{<:Any,1,<:Tuple{<:OneToInf}}) =
+    cumsum(r1*getindex_value(r2))
+conv(r2::AbstractFill{<:Any,1,<:Tuple{<:OneToInf}}, r1::InfRanges) =
+    cumsum(getindex_value(r2)*r1)
+
+conv(r1::InfRanges, r2::Ones{<:Any,1,<:Tuple{<:OneToInf}}) = cumsum(r1)
+conv(r2::Ones{<:Any,1,<:Tuple{<:OneToInf}}, r1::InfRanges) = cumsum(r1)
+
+conv(r1::InfRanges, r2::InfRanges) = throw(ArgumentError("conv(::$(typeof(r1)), ::$(typeof(r2))) not implemented"))
+
+function conv(r1::AbstractFill{<:Any,1,<:Tuple{<:OneToInf}}, r2::AbstractFill{<:Any,1,<:Tuple{<:OneToInf}})
+    a = getindex_value(r1) * getindex_value(r2)
+    a:a:∞
+end
+function conv(r1::AbstractFill{<:Any,1,<:Tuple{<:OneToInf}}, r2::Ones{<:Any,1,<:Tuple{<:OneToInf}})
+    a = getindex_value(r1) * getindex_value(r2)
+    a:a:∞
+end
+function conv(r1::Ones{<:Any,1,<:Tuple{<:OneToInf}}, r2::AbstractFill{<:Any,1,<:Tuple{<:OneToInf}})
+    a = getindex_value(r1) * getindex_value(r2)
+    a:a:∞
+end
+
+
+end

--- a/src/InfiniteArrays.jl
+++ b/src/InfiniteArrays.jl
@@ -224,6 +224,7 @@ end
 
 if !isdefined(Base, :get_extension)
     include("../ext/InfiniteArraysStatisticsExt.jl")
+    include("../ext/InfiniteArraysDSPExt.jl")
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1179,3 +1179,5 @@ end
     # check that show works
     Base.sprint(show, I(ℵ₀), context=:limit=>true)
 end
+
+include("test_infconv.jl")

--- a/test/test_infconv.jl
+++ b/test/test_infconv.jl
@@ -1,0 +1,17 @@
+using InfiniteArrays, DSP, FillArrays, Test
+using Base: oneto
+
+@testset "conv" begin
+    @test conv(1:∞, [2]) ≡ conv([2], 1:∞) ≡ 2:2:∞
+    @test conv(1:2:∞, [2]) ≡ conv([2], 1:2:∞) ≡ 2:4:∞
+    @test conv(1:∞, Ones(∞))[1:5] == conv(Ones(∞),1:∞)[1:5] == [1,3,6,10,15]
+    @test conv(Ones(∞), Ones(∞)) ≡ 1.0:1.0:∞
+    @test conv(Ones{Int}(∞), Ones{Int}(∞)) ≡ oneto(∞)
+    @test conv(Ones{Bool}(∞), Ones{Bool}(∞)) ≡ oneto(∞)
+    @test conv(Fill{Int}(2,∞), Fill{Int}(1,∞)) ≡ conv(Fill{Int}(2,∞), Ones{Int}(∞)) ≡
+                conv(Ones{Int}(∞), Fill{Int}(2,∞)) ≡ 2:2:∞
+    @test conv(Ones{Int}(∞), [1,5,8])[1:10] == conv([1,5,8], Ones{Int}(∞))[1:10] ==
+                    conv(fill(1,100),[1,5,8])[1:10] == conv([1,5,8], fill(1,100))[1:10]
+    @test conv(Ones{Int}(∞), 1:4)[1:10] == conv(1:4, Ones{Int}(∞))[1:10] ==
+                    conv(fill(1,100),collect(1:4))[1:10] == conv(collect(1:4), fill(1,100))[1:10]
+end


### PR DESCRIPTION
These were being defined in `InfiniteLinearAlgebra` through type-piracy, but they may be defined here in a package extension.