### PR TITLE
Specialize axes for InfRanges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -144,6 +144,7 @@ AbstractVector{T}(a::OneToInf) where T<:Real = InfUnitRange{T}(a)
 ## interface implementations
 
 size(r::InfRanges) = (ℵ₀,)
+axes(r::InfRanges) = (OneToInf(),)
 
 isempty(r::InfRanges) = false
 


### PR DESCRIPTION
Since the fallback method that used to use `oneto` is now removed on v1.11, we need to specialize `axes` for `InfRange`s. In any case, since `oneto` is internal to `Base`, it's best to not rely on it unless absolutely necessary.