### PR TITLE
Fix indexing `BigInt` axes with large indices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/InfiniteArrays.jl
+++ b/src/InfiniteArrays.jl
@@ -161,10 +161,10 @@ axistype(::OneToInf{V}, ::OneTo{T}) where {T,V} = OneToInf{promote_type(T,V)}()
 # returns the range of indices of v equal to x
 # if v does not contain x, returns a 0-length range
 # indicating the insertion point of x
-function searchsorted(v::AbstractVector, x, ilo::Int, ::PosInfinity, o::Ordering)
+function searchsorted(v::AbstractVector, x, ilo::Integer, ::PosInfinity, o::Ordering)
     lo = ilo-1
     hi = ℵ₀
-    @inbounds while lo < hi-1
+    while lo < hi-1
         m = isinf(hi) ? lo + 1000 : (lo+hi)>>>1
         if lt(o, v[m], x)
             lo = m
@@ -182,11 +182,11 @@ end
 
 # index of the first value of vector a that is greater than or equal to x;
 # returns length(v)+1 if x is greater than all values in v.
-function searchsortedfirst(v::AbstractVector, x, lo::Int, hi::PosInfinity, o::Ordering)
+function searchsortedfirst(v::AbstractVector, x, lo::Integer, hi::PosInfinity, o::Ordering)
    u = 1
    lo = lo - u
    hi = ℵ₀
-   @inbounds while lo < hi - u
+   while lo < hi - u
       m = isinf(hi) ? lo + 1000 : (lo+hi)>>>1
       if lt(o, v[m], x)
          lo = m
@@ -199,11 +199,11 @@ end
 
 # index of the last value of vector a that is less than or equal to x;
 # returns 0 if x is less than all values of v.
-function searchsortedlast(v::AbstractVector, x, lo::Int, hi::PosInfinity, o::Ordering)
+function searchsortedlast(v::AbstractVector, x, lo::Integer, hi::PosInfinity, o::Ordering)
    u = 1
    lo = lo - u
    hi = ℵ₀
-   @inbounds while lo < hi - u
+   while lo < hi - u
        m = isinf(hi) ? lo + 1000 : (lo+hi)>>>1
        if lt(o, x, v[m])
            hi = m

--- a/src/InfiniteArrays.jl
+++ b/src/InfiniteArrays.jl
@@ -164,7 +164,7 @@ axistype(::OneToInf{V}, ::OneTo{T}) where {T,V} = OneToInf{promote_type(T,V)}()
 function searchsorted(v::AbstractVector, x, ilo::Integer, ::PosInfinity, o::Ordering)
     lo = ilo-1
     hi = ℵ₀
-    while lo < hi-1
+    @inbounds while lo < hi-1
         m = isinf(hi) ? lo + 1000 : (lo+hi)>>>1
         if lt(o, v[m], x)
             lo = m
@@ -186,7 +186,7 @@ function searchsortedfirst(v::AbstractVector, x, lo::Integer, hi::PosInfinity, o
    u = 1
    lo = lo - u
    hi = ℵ₀
-   while lo < hi - u
+   @inbounds while lo < hi - u
       m = isinf(hi) ? lo + 1000 : (lo+hi)>>>1
       if lt(o, v[m], x)
          lo = m
@@ -203,7 +203,7 @@ function searchsortedlast(v::AbstractVector, x, lo::Integer, hi::PosInfinity, o:
    u = 1
    lo = lo - u
    hi = ℵ₀
-   while lo < hi - u
+   @inbounds while lo < hi - u
        m = isinf(hi) ? lo + 1000 : (lo+hi)>>>1
        if lt(o, x, v[m])
            hi = m

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -144,6 +144,7 @@ AbstractVector{T}(a::OneToInf) where T<:Real = InfUnitRange{T}(a)
 ## interface implementations
 
 size(r::InfRanges) = (ℵ₀,)
+axes(r::InfRanges{<:Integer}) = (OneToInf{promote_type(Int,eltype(r))}(),)
 axes(r::InfRanges) = (OneToInf(),)
 
 isempty(r::InfRanges) = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,6 +125,11 @@ end
     @test ∞:1 ≡ 1:0
 
     @testset "indexing" begin
+        @testset "axes" begin
+            r = axes(big(1):∞,1)
+            @test r == axes(r,1)
+            @test r[typemax(Int)+big(1)] == typemax(Int)+big(1)
+        end
         L32 = @inferred(Int32(1):∞)
         L64 = @inferred(Int64(1):∞)
         @test @inferred(L32[1]) === Int32(1) && @inferred(L64[1]) === Int64(1)


### PR DESCRIPTION
This uses type-promotion for integer ranges to widen the axis type, which makes the result correct for large `BigInt` arguments. I don't like the special-casing, but I couldn't figure out how to work around floating-point ranges.

This required changing certain `searchsorted` methods to accept `Integer` instead of `Int`, which improves `BigInt` support. I've also removed the `@inbounds` annotations, as this isn't necessarily guaranteed. Since these are `O(log n)` operations, the expense of bounds-checking should not be much.