### PR TITLE
Remove permutedims specialization for Diagonal

### DIFF
--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -574,7 +574,9 @@ end
 
 FillArrays._range_convert(::Type{AbstractVector{T}}, r::InfRanges) where T = convert(AbstractVector{T}, r)
 
-
+if VERSION <= v"1.9"
+    permutedims(D::Diagonal{<:Any,<:InfRanges}) = D
+end
 copy(D::Diagonal{<:Any,<:InfRanges}) = D
 broadcasted(::LazyArrayStyle{2}, ::typeof(*), a::Number, D::Diagonal{<:Any,<:InfRanges}) = a*D
 broadcasted(::LazyArrayStyle{2}, ::typeof(*), D::Diagonal{<:Any,<:InfRanges}, a::Number) = D*a

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -575,7 +575,6 @@ end
 FillArrays._range_convert(::Type{AbstractVector{T}}, r::InfRanges) where T = convert(AbstractVector{T}, r)
 
 
-permutedims(D::Diagonal{<:Any,<:InfRanges}) = D
 copy(D::Diagonal{<:Any,<:InfRanges}) = D
 broadcasted(::LazyArrayStyle{2}, ::typeof(*), a::Number, D::Diagonal{<:Any,<:InfRanges}) = a*D
 broadcasted(::LazyArrayStyle{2}, ::typeof(*), D::Diagonal{<:Any,<:InfRanges}, a::Number) = D*a


### PR DESCRIPTION
This specialized method is unnecessary, as the fallback method for `Diagonal` does the same.

Edit: the method is now version-limited to Julia releases older than v1.9.