### PR TITLE
Specialize diag for infinite Diagonal

### DIFF
--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -579,3 +579,11 @@ permutedims(D::Diagonal{<:Any,<:InfRanges}) = D
 copy(D::Diagonal{<:Any,<:InfRanges}) = D
 broadcasted(::LazyArrayStyle{2}, ::typeof(*), a::Number, D::Diagonal{<:Any,<:InfRanges}) = a*D
 broadcasted(::LazyArrayStyle{2}, ::typeof(*), D::Diagonal{<:Any,<:InfRanges}, a::Number) = D*a
+
+function LinearAlgebra.diag(D::Diagonal{<:Any,<:InfRanges}, k::Integer = 0)
+    if k == 0
+        return parent(D)
+    else
+        return Zeros{eltype(D)}(size(D,1)) # infinite vector of zeros
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1159,4 +1159,12 @@ end
     @test [k * (k+1) for k = 1:2.0:∞] isa AbstractVector{Float64}
 end
 
+@testset "diag" begin
+    D = Diagonal(1:∞)
+    @test @inferred(diag(D)) === 1:∞
+    @test @inferred((D -> diag(D,1))(D)) === Zeros{Int}(ℵ₀)
+    # test for compile-time evaluation of off-diagonals
+    @inferred Val((D -> diag(D,1))(D))
+end
+
 include("test_infconv.jl")


### PR DESCRIPTION
Address the specific example from #147

After this,
```julia
julia> D = Diagonal(1:∞);

julia> diag(D)
1:∞

julia> diag(D,1)
ℵ₀-element Zeros{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}} with indices OneToInf()
```