### PR TITLE
Specialize checked_length for InfRanges

### DIFF
--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -152,7 +152,9 @@ isempty(r::InfRanges) = false
 step(r::InfStepRange) = r.step
 
 length(r::InfRanges) = ℵ₀
-Base.checked_length(r::InfRanges) = ℵ₀
+if VERSION >= v"1.7"
+    Base.checked_length(r::InfRanges) = ℵ₀
+end
 unsafe_length(r::InfRanges) = ℵ₀
 
 first(r::OneToInf{T}) where {T} = oneunit(T)

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -152,6 +152,7 @@ isempty(r::InfRanges) = false
 step(r::InfStepRange) = r.step
 
 length(r::InfRanges) = ℵ₀
+Base.checked_length(r::InfRanges) = ℵ₀
 unsafe_length(r::InfRanges) = ℵ₀
 
 first(r::OneToInf{T}) where {T} = oneunit(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,6 +167,8 @@ end
         @test length(2:-.2:-∞) == ℵ₀
         @test length(2.:-.2:-∞) == ℵ₀
 
+        @test Base.checked_length(1:∞) == length(1:∞)
+
         @testset "IteratorSize" begin
             @test Base.IteratorSize(1:2:∞) == Base.IsInfinite()
             @test Base.IteratorSize(1:∞) == Base.IsInfinite()
@@ -174,6 +176,11 @@ end
             @test first(s) == 2
             @test first(s) == 3
         end
+    end
+
+    @testset "first" begin
+        @test first(1:4:∞) == 1
+        @test first(1:4:∞, 4) == range(1, step=4, length=4)
     end
 
     @testset "intersect" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,7 +167,9 @@ end
         @test length(2:-.2:-∞) == ℵ₀
         @test length(2.:-.2:-∞) == ℵ₀
 
-        @test Base.checked_length(1:∞) == length(1:∞)
+        if VERSION >= v"1.7"
+            @test Base.checked_length(1:∞) == length(1:∞)
+        end
 
         @testset "IteratorSize" begin
             @test Base.IteratorSize(1:2:∞) == Base.IsInfinite()


### PR DESCRIPTION
This gets the following to work:
```julia
julia> first(1:4:∞, 4)
1:4:13
```