### PR TITLE
Specialize unchecked_oneto

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -133,6 +133,10 @@ function oneto(x::ComplexInfinity)
     throw(ArgumentError("Cannot create infinite range with negative length"))
  end
 
+@static if VERSION >= v"1.11.0-"
+    Base.unchecked_oneto(::PosInfinity) = OneToInf()
+end
+
 AbstractArray{T}(a::OneToInf) where T<:Integer = OneToInf{T}()
 AbstractVector{T}(a::OneToInf) where T<:Integer = OneToInf{T}()
 AbstractArray{T}(a::OneToInf) where T<:Real = InfUnitRange{T}(a)


### PR DESCRIPTION
On upcoming julia versions, Base occasionally uses `unchecked_oneto` where it used to previously use `oneto`. This requires us to specialize `unchecked_oneto` as well to get tests to pass.

See https://github.com/JuliaLang/julia/issues/52481