### PR TITLE
Union for `OneToInf` `RangeCumsum`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.13.5"
+version = "0.13.6"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -519,6 +519,10 @@ diff(r::InfRanges) = Fill(step(r),∞)
 diff(r::OneToInf{T}) where T = Ones{T}(∞)
 Base.@propagate_inbounds getindex(c::RangeCumsum, kr::OneToInf) = RangeCumsum(c.range[kr])
 getindex(c::RangeCumsum{<:Any,<:OneToInf}, k::Integer) = k * (k+1) ÷ 2
+function union(r1::RangeCumsum{T1, OneToInf{T1}}, r2::RangeCumsum{T2, OneToInf{T2}}) where {T1,T2}
+    T = promote_type(T1, T2)
+    RangeCumsum(OneToInf{T}())
+end
 
 # vcat
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -399,13 +399,6 @@ end
             @test axes(z) == (Base.OneTo(100),)
             @test size(z) == (100,)
         end
-
-        @testset "union of cumsum" begin
-            r1 = InfiniteArrays.OneToInf{Int8}()
-            r2 = InfiniteArrays.OneToInf{Int16}()
-            rs = union(cumsum(r1), cumsum(r2))
-            @test rs == cumsum(r2)
-        end
     end
 
     @testset "show" begin
@@ -930,6 +923,13 @@ end
     end
 
     @test cumsum(1:∞)[2:∞][1:5] == cumsum(1:6)[2:end]
+
+    @testset "union of cumsum" begin
+        r1 = InfiniteArrays.OneToInf{Int8}()
+        r2 = InfiniteArrays.OneToInf{Int16}()
+        rs = union(cumsum(r1), cumsum(r2))
+        @test rs == cumsum(r2)
+    end
 end
 
 @testset "Sub-array" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -399,6 +399,13 @@ end
             @test axes(z) == (Base.OneTo(100),)
             @test size(z) == (100,)
         end
+
+        @testset "union of cumsum" begin
+            r1 = InfiniteArrays.OneToInf{Int8}()
+            r2 = InfiniteArrays.OneToInf{Int16}()
+            rs = union(cumsum(r1), cumsum(r2))
+            @test rs == cumsum(r2)
+        end
     end
 
     @testset "show" begin


### PR DESCRIPTION
This allows
```julia
julia> r = InfiniteArrays.OneToInf()
OneToInf()

julia> rs = cumsum(r);

julia> union(rs, rs)
ℵ₀-element RangeCumsum{Int64, InfiniteArrays.OneToInf{Int64}} with indices OneToInf():
   1
   3
   6
  10
  15
  21
  28
  36
  45
  55
  66
  78
  91
 105
 120
 136
 153
 171
   ⋮
```