### PR TITLE
Diff for infinite unit range returns Ones

### DIFF
--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -516,7 +516,7 @@ broadcast(f, r::Transpose{<:Any,<:InfRanges}, a::Number) = transpose(broadcast(f
 # cumsum(r::InfRanges) = OneToInf() .* (first(r) .+ r) .÷ 2
 cumsum(r::InfRanges) = RangeCumsum(r)
 diff(r::InfRanges) = Fill(step(r),∞)
-diff(r::OneToInf{T}) where T = Ones{T}(∞)
+diff(r::AbstractInfUnitRange{T}) where T = Ones{T}(∞)
 Base.@propagate_inbounds getindex(c::RangeCumsum, kr::OneToInf) = RangeCumsum(c.range[kr])
 getindex(c::RangeCumsum{<:Any,<:OneToInf}, k::Integer) = k * (k+1) ÷ 2
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -897,7 +897,7 @@ end
     @test cumsum(Ones{BigInt}(∞)) ≡ OneToInf{BigInt}()
 
     @test diff(oneto(∞)) ≡ Ones{Int}(∞)
-    @test diff(1:∞) ≡ Fill(1,∞)
+    @test diff(1:∞) ≡ Ones{Int}(∞)
     @test diff(1:2:∞) ≡ Fill(2,∞)
     @test diff(1:2.0:∞) ≡ Fill(2.0,∞)
 


### PR DESCRIPTION
On master
```julia
julia> diff(1:∞)
ℵ₀-element Fill{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}} with indices OneToInf(), with entries equal to 1
```
This PR
```julia
julia> diff(1:∞)
ℵ₀-element Ones{Int64, 1, Tuple{InfiniteArrays.OneToInf{Int64}}} with indices OneToInf()
```