### PR TITLE
Allow findfirst(isone) and findfirst(iszero) for InfRanges

### DIFF
--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -599,7 +599,8 @@ for op in (:isequal, :(==))
             isinteger(p.x) ? findfirst($op(convert(V, p.x)), r) : nothing
     end
 end
-
+findfirst(::typeof(isone), r::InfRanges{T}) where {T} = findfirst(==(one(T)), r)
+findfirst(::typeof(iszero), r::InfRanges{T}) where {T} = findfirst(==(zero(T)), r)
 
 FillArrays._range_convert(::Type{AbstractVector{T}}, r::InfRanges) where T = convert(AbstractVector{T}, r)
 
@@ -618,9 +619,9 @@ function LinearAlgebra.diag(D::Diagonal{<:Any,<:InfRanges}, k::Integer = 0)
     end
 end
 
-function inv(D::Diagonal{T, <:InfRanges}) where {T} 
+function inv(D::Diagonal{<:Any, <:InfRanges})
     d = D.diag 
-    idx = findfirst(==(zero(T)), d) 
+    idx = findfirst(iszero, d) 
     isnothing(idx) || throw(SingularException(idx))
     return Diagonal(inv.(d))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1097,6 +1097,17 @@ end
     @test searchsorted(factorial.(big(1):∞), 6) == 3:3
     @test searchsortedfirst(factorial.(big(1):∞), 7) == 4
     @test searchsortedlast(factorial.(big(1):∞), 7) == 3
+
+    @testset "Issue #178" begin
+        findfirst(isone, 1:∞) == 1 
+        findfirst(isone, 0:2:∞) === nothing
+        findfirst(isone, -5:∞) == 7
+        findfirst(isone, 2:∞) === nothing 
+        findfirst(iszero, 0:∞) == 1 
+        findfirst(iszero, 5:∞) === nothing 
+        findfirst(iszero, 0.5:∞) === nothing 
+        findfirst(iszero, -5.0:2.5:∞) == 3
+    end
 end
 
 @testset "convert infrange" begin


### PR DESCRIPTION
Fixes #178 

Also changes my previous PR #177 to use the new findfirst(iszero)