### PR TITLE
Fix #182

### DIFF
--- a/src/InfiniteArrays.jl
+++ b/src/InfiniteArrays.jl
@@ -49,7 +49,7 @@ import LinearAlgebra: AdjOrTrans, HermOrSym, diag, norm, norm1, norm2, normp
 
 import LazyArrays: AbstractPaddedLayout
 
-import Random: default_rng
+import Random: default_rng, seed!
 
 export ∞, ℵ₀, Hcat, Vcat, Zeros, Ones, Fill, Eye, BroadcastArray, cache
 import Base: unitrange, oneto

--- a/test/test_infrand.jl
+++ b/test/test_infrand.jl
@@ -13,6 +13,7 @@
         @test size(seq) == (ℵ₀,)
         @test length(seq) == ℵ₀
         @test axes(seq) == (1:ℵ₀,)
+        @inferred InfiniteArrays._single_rand(seq)
     end
 
     @testset "Providing an RNG and a distribution" begin
@@ -20,6 +21,7 @@
         seq = InfiniteArrays.InfRandVector(rng, Float16)
         rng2 = MersenneTwister(123)
         @test seq[1:10000] == [rand(rng2, Float16) for _ in 1:10000]
+        @inferred InfiniteArrays._single_rand(seq)
     end 
 
     @testset "Distributions.jl" begin 
@@ -28,5 +30,18 @@
         seq = InfiniteArrays.InfRandVector(rng, dist)
         rng2 = Xoshiro(5)
         @test seq[1:100] == [0.3 + 1.7randn(rng2) for _ in 1:100]
+
+        @test InfiniteArrays._dist_type(dist) == Normal{Float64}
+        @test InfiniteArrays._dist_type(Float64) == Type{Float64}
+        @inferred InfiniteArrays._single_rand(seq)
+    end
+
+    @testset "Issue #182" begin
+        kp = InfiniteArrays.InfRandVector()[1:1000]
+        kp2 = InfiniteArrays.InfRandVector()[1:1000]
+        kp3 = InfiniteArrays.InfRandVector()[1:1000]
+        @test kp ≠ kp2 
+        @test kp2 ≠ kp3 
+        @test kp ≠ kp3
     end
 end


### PR DESCRIPTION
Fixes #182 

The fix just reseeds the user's `rng` with a new random seed (that is sampled using `rng` so that it is reproducible). I also fixed an issue with type stability where giving `Float64` as a dist put `DataType` into the `D` parameter of `InfRandVector`, leading to type instabilities from `rand(rng, D) where D <: DataType`.