### PR TITLE
Fast bounds-check for infinite CartesianIndex StepRangeLen

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.14.2"
+version = "0.14.3"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -625,3 +625,8 @@ function inv(D::Diagonal{<:Any, <:InfRanges})
     isnothing(idx) || throw(SingularException(idx))
     return Diagonal(inv.(d))
 end
+
+# bounds-checking
+function Base.checkindex(::Type{Bool}, inds::NTuple{N, AbstractInfUnitRange}, i::AbstractRange{CartesianIndex{N}}) where {N}
+    isempty(i) | checkindex(Bool, inds, first(i))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1231,3 +1231,10 @@ end
 
 include("test_infconv.jl")
 include("test_block.jl")
+
+@testset "bounds-checking for StepRangeLen{<:CartesianIndex}" begin
+    if VERSION >= v"1.11.0-rc3"
+        D = Diagonal(1:∞)
+        @test checkbounds(Bool, D, diagind(D, IndexCartesian()))
+    end
+end


### PR DESCRIPTION
Julia v1.11 allows `StepRangeLen{<:CartesianIndex}` indices, but the bounds-check for such a range falls back to element-wise iteration. The other issue with such an infinite range is that `last` can't be defined as a `CartesianIndex`, as it only accepts `Int`s.
In this PR, we define `checkindex` for such indices by only comparing the starting point. This would allow bounds-checking for infinite arrays with such indices.