### PR TITLE
Fix findfirst for InfStepRange for negative step

### DIFF
--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -571,7 +571,7 @@ MemoryLayout(::Type{<:AbstractInfUnitRange}) = LazyLayout()
 
 # from array.jl
 function _step_findfirst(p, r::InfStepRange{T,S}) where {T,S}
-    first(r) <= p.x || return nothing
+    first(r) <= p.x && step(r) > zero(step(r)) || first(r) >= p.x && step(r) < zero(step(r)) || return nothing
     d = convert(S, p.x - first(r))
     iszero(d % step(r)) || return nothing
     return d ÷ step(r) + 1

--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -571,7 +571,7 @@ MemoryLayout(::Type{<:AbstractInfUnitRange}) = LazyLayout()
 
 # from array.jl
 function _step_findfirst(p, r::InfStepRange{T,S}) where {T,S}
-    first(r) <= p.x && step(r) > zero(step(r)) || first(r) >= p.x && step(r) < zero(step(r)) || return nothing
+    (first(r) <= p.x && step(r) > zero(step(r))) || (first(r) >= p.x && step(r) < zero(step(r))) || return nothing
     d = convert(S, p.x - first(r))
     iszero(d % step(r)) || return nothing
     return d ÷ step(r) + 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1229,6 +1229,16 @@ end
     @test v[1:∞] == v
 end
 
+@testset "issue #180" begin
+    @test isnothing(findfirst(==(21), 10:-1:-∞))
+    @test isnothing(findfirst(==(11), 10:-1:-∞))
+    @test findfirst(==(9), 10:-1:-∞) == 2
+    r = 10:-1:-∞
+    v = -20
+    ind = findfirst(==(v), r)
+    @test r[ind] == v
+end
+
 include("test_infconv.jl")
 include("test_block.jl")
 


### PR DESCRIPTION
Fixes https://github.com/JuliaArrays/InfiniteArrays.jl/issues/180

After this,
```julia
julia> findfirst(==(9), 10:-1:-∞)
2

julia> findfirst(==(11), 10:-1:-∞)

julia> findfirst(==(21), 10:-1:-∞)
```