### PR TITLE
`file` -> `files` in CI codecov step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,4 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: lcov.info
+          files: lcov.info


### PR DESCRIPTION
`file` is deprecated in the v5 release of the codecov Github action