### PR TITLE
Preserve infinite step ranges in views (#203)

### DIFF
--- a/src/infrange.jl
+++ b/src/infrange.jl
@@ -284,6 +284,10 @@ function getindex(Ac::AdjOrTrans{<:Any,<:InfRanges}, k::Integer, j::InfAxes)
     parent(Ac)[j]
 end
 
+# views may preserve InfStepRanges
+Base.@propagate_inbounds Base.view(r::InfStepRange, i::AbstractUnitRange{<:Integer}) = r[i]
+Base.@propagate_inbounds Base.view(r::InfStepRange, i::InfStepRange{<:Integer}) = r[i]
+Base.@propagate_inbounds Base.view(r::InfStepRange, i::StepRange{<:Integer}) = r[i]
 
 show(io::IO, r::InfUnitRange) = print(io, repr(first(r)), ':', repr(∞))
 show(io::IO, r::OneToInf{Int}) = print(io, "OneToInf()")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -391,6 +391,16 @@ end
         @test (1:-1:-∞)[1:∞] == 1:-1:-∞
     end
 
+    @testset "view(InfStepRange, inf-range)" begin
+        r = 2:5:∞
+        @test view(r, axes(r,1)) === r
+        @test view(r, 1:1:∞) === r
+        @test view(r, 2:2:∞) === 7:10:∞
+        r2 = 2:5:10_000 # arbitrary high upper cutoff
+        @test view(r, 4:10) == view(r2, 4:10)
+        @test view(r, 4:7:50) == view(r2, 4:7:50)
+    end
+
     @testset "OneToInf" begin
         r = OneToInf()
         @test !isempty(r)


### PR DESCRIPTION
This backports the PR https://github.com/JuliaArrays/InfiniteArrays.jl/pull/203 to the v0.14 release