### PR TITLE
Fix `BroadcastStyle` for `FillArrays`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InfiniteArrays"
 uuid = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
-version = "0.15.5"
+version = "0.15.6"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/infarrays.jl
+++ b/src/infarrays.jl
@@ -167,9 +167,10 @@ end
 # Lazy Broadcasting
 for typ in (:Ones, :Zeros, :Fill)
     @eval begin
-        BroadcastStyle(::Type{$typ{T,N,NTuple{N,<:OneToInf}}}) where {T,N} = LazyArrayStyle{N}()
-        BroadcastStyle(::Type{$typ{T,2,<:Tuple{<:Any,<:OneToInf}}}) where {T} = LazyArrayStyle{2}()
-        BroadcastStyle(::Type{$typ{T,2,<:Tuple{<:OneToInf,<:Any}}}) where {T} = LazyArrayStyle{2}()
+        BroadcastStyle(::Type{<:$typ{T,N,<:Tuple{OneToInf, Vararg{OneToInf}}}}) where {T,N} = LazyArrayStyle{N}()
+        BroadcastStyle(::Type{<:$typ{T,2,<:Tuple{Any,OneToInf}}}) where {T} = LazyArrayStyle{2}()
+        BroadcastStyle(::Type{<:$typ{T,2,<:Tuple{OneToInf,Any}}}) where {T} = LazyArrayStyle{2}()
+        BroadcastStyle(::Type{<:$typ{T,2,<:Tuple{OneToInf,OneToInf}}}) where {T} = LazyArrayStyle{2}()
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -884,6 +884,13 @@ end
         @test broadcast(*, 1:∞, Fill(2,∞)') isa BroadcastArray
         @test broadcast(*, Diagonal(1:∞), Ones{Int}(∞)') ≡ broadcast(*, Ones{Int}(∞)', Diagonal(1:∞)) ≡ Diagonal(1:∞)
         @test broadcast(*, Diagonal(1:∞), Fill(2,∞)') ≡ broadcast(*, Fill(2,∞)', Diagonal(1:∞)) ≡ Diagonal(2:2:∞)
+
+        @test !(Broadcast.BroadcastStyle(typeof(Fill(4))) isa LazyArrayStyle)
+        @test Broadcast.BroadcastStyle(typeof(Fill(4, ∞))) isa LazyArrayStyle{1}
+        @test Broadcast.BroadcastStyle(typeof(Fill(4, ∞, ∞))) isa LazyArrayStyle{2}
+        @test Broadcast.BroadcastStyle(typeof(Fill(4, ∞, 1))) isa LazyArrayStyle{2}
+        @test Broadcast.BroadcastStyle(typeof(Fill(4, 1, ∞))) isa LazyArrayStyle{2}
+        @test Broadcast.BroadcastStyle(typeof(Fill(4, ∞, ∞, ∞))) isa LazyArrayStyle{3}
     end
 
     @testset "subview inf broadcast" begin


### PR DESCRIPTION
Currently,
```julia
julia> F = Fill(3)
0-dimensional Fill{Int64}, with entry equal to 3

julia> Broadcast.BroadcastStyle(typeof(F))
LazyArrays.LazyArrayStyle{0}()
```
This PR fixes this type-piracy, and ensures that this returns `DefaultArrayStyle{0}`.

This PR also resolves a method ambiguity in the 2D case, and makes the `BroadcastStyle` a `LazyArrayStyle` for infinite fill arrays
```julia
julia> Broadcast.BroadcastStyle(typeof(F))
LazyArrays.LazyArrayStyle{1}()
```