### PR TITLE
Fix broadcaststyle for 0d FillArray

### DIFF
--- a/src/infarrays.jl
+++ b/src/infarrays.jl
@@ -167,7 +167,7 @@ end
 # Lazy Broadcasting
 for typ in (:Ones, :Zeros, :Fill)
     @eval begin
-        BroadcastStyle(::Type{$typ{T,N,NTuple{N,<:OneToInf}}}) where {T,N} = LazyArrayStyle{N}()
+        BroadcastStyle(::Type{$typ{T,N,<:Tuple{OneToInf,Vararg{OneToInf}}}}) where {T,N} = LazyArrayStyle{N}()
         BroadcastStyle(::Type{$typ{T,2,<:Tuple{<:Any,<:OneToInf}}}) where {T} = LazyArrayStyle{2}()
         BroadcastStyle(::Type{$typ{T,2,<:Tuple{<:OneToInf,<:Any}}}) where {T} = LazyArrayStyle{2}()
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -884,6 +884,8 @@ end
         @test broadcast(*, 1:∞, Fill(2,∞)') isa BroadcastArray
         @test broadcast(*, Diagonal(1:∞), Ones{Int}(∞)') ≡ broadcast(*, Ones{Int}(∞)', Diagonal(1:∞)) ≡ Diagonal(1:∞)
         @test broadcast(*, Diagonal(1:∞), Fill(2,∞)') ≡ broadcast(*, Fill(2,∞)', Diagonal(1:∞)) ≡ Diagonal(2:2:∞)
+
+        @test !(Broadcast.BroadcastStyle(typeof(Fill(4))) isa LazyArrayStyle)
     end
 
     @testset "subview inf broadcast" begin


### PR DESCRIPTION
Reland the `0d` `Fill` fix from #215

After this,
```julia
julia> Broadcast.BroadcastStyle(typeof(Fill(4)))
Base.Broadcast.DefaultArrayStyle{0}()
```
and this method isn't being accidentally pirated by `InfiniteArrays`.